### PR TITLE
mention qemu-img and install it

### DIFF
--- a/INSTALL-SLES-15-SP5.md
+++ b/INSTALL-SLES-15-SP5.md
@@ -40,7 +40,7 @@ replace the default version shipped by the distribution. To install all required
 packages, do:
 
 ```
-$ sudo zypper install --allow-vendor-change kernel-default qemu qemu-ovmf-tdx-x86_64
+$ sudo zypper install --allow-vendor-change kernel-default qemu qemu-ovmf-tdx-x86_64 qemu-img
 ```
 
 This command will install a TDX capable kernel and QEMU together with the


### PR DESCRIPTION
mention qemu-img and install it, but BEWARE!

The current mechanism to make the package incompatible with the normal SUSE qemu package currently DOES NOT WORK.

We need to completely review how this works, because an installation with a pre-existing stack will not work depending on repo priority , and an installation without a pre-existing stack will also not work due to missing qemu-img.

We need to mark the packages in tdx-demo as incompatible with qemu from the normal repo, including virtiofsd and qemu-img, we need to add a qemu-img tool to the separate tdx repo.

